### PR TITLE
Shouldn't allow adding a condition without outcome slots

### DIFF
--- a/contracts/PredictionMarketSystem.sol
+++ b/contracts/PredictionMarketSystem.sol
@@ -65,6 +65,7 @@ contract PredictionMarketSystem is OracleConsumer, ERC1155 {
     /// @param outcomeSlotCount The number of outcome slots which should be used for this condition. Must not exceed 256.
     function prepareCondition(address oracle, bytes32 questionId, uint outcomeSlotCount) external {
         require(outcomeSlotCount <= 256, "too many outcome slots");
+        require(outcomeSlotCount > 0, "no outcome slots provided");
         bytes32 conditionId = keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount));
         require(payoutNumerators[conditionId].length == 0, "condition already prepared");
         payoutNumerators[conditionId] = new uint[](outcomeSlotCount);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3685,8 +3685,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3707,14 +3706,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3729,20 +3726,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3859,8 +3853,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3872,7 +3865,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3887,7 +3879,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3895,14 +3886,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3921,7 +3910,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4009,8 +3997,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4022,7 +4009,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4108,8 +4094,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4145,7 +4130,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4165,7 +4149,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4209,14 +4192,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8142,7 +8123,8 @@
       "requires": {
         "app-module-path": "^2.2.0",
         "mocha": "^4.1.0",
-        "original-require": "1.0.1"
+        "original-require": "1.0.1",
+        "solc": "0.5.0"
       }
     },
     "truffle-blockchain-utils": {
@@ -10167,7 +10149,7 @@
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "dev": true,
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
             "ethereumjs-util": "^5.1.1"
           }
         },
@@ -10235,7 +10217,7 @@
         "lodash": "^4.17.11",
         "oboe": "2.1.4",
         "url-parse": "1.4.4",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
         "xhr2-cookies": "1.1.0"
       }
     },
@@ -10377,7 +10359,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "bn.js": {

--- a/test/test_pm_system.js
+++ b/test/test_pm_system.js
@@ -38,6 +38,17 @@ contract("PredictionMarketSystem", function(accounts) {
     );
   });
 
+  it("should not be able to prepare a condition with no outomes slots", async () => {
+    await assertRejects(
+      predictionMarketSystem.prepareCondition(
+        oracle,
+        questionId,
+        0
+      ),
+      "Transaction should have reverted."
+    );
+  });
+
   it("should have obtainable conditionIds if in possession of oracle, questionId, and outcomeSlotCount", async () => {
     assert.equal(
       (await predictionMarketSystem.getOutcomeSlotCount(conditionId)).valueOf(),


### PR DESCRIPTION
Hi guys, 
Just a tiny issue. It's possible to add hollow conditions that might pollute the prediction market system. It could be trivially fixed by an additional validation so I'm proposing this PR.