### PR TITLE
add public ID calculation helpers

### DIFF
--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -81,7 +81,7 @@ To prepare this condition, the following code gets run:
         3
     )
 
-The condition ID may also be determined from the parameters via:
+The condition ID may be determined off-chain from the parameters via ``web3``:
 
 .. code-block:: js
 
@@ -95,6 +95,10 @@ The condition ID may also be determined from the parameters via:
         t: 'uint',
         v: 3
     })
+
+A helper function for determining the condition ID also exists on the contract:
+
+.. autosolfunction:: ConditionalTokens.getConditionID
 
 This yields a condition ID of ``0x67eb23e8932765c1d7a094838c928476df8c50d1d3898f278ef1fb2a62afab63``.
 
@@ -185,6 +189,10 @@ The combined collection ID for ``(A|B)&(LO)`` can be calculated via:
 
 This calculation yields the value ``0x2a9b72306758380e3b0a31125ed39a635432b283180c41b3fe8b5f5eb4971df4``.
 
+Similar to with conditions, the contract also provides a helper function for calculating outcome collection IDs:
+
+.. autosolfunction:: ConditionalTokens.getCollectionID
+
 .. _BigInt: https://tc39.github.io/proposal-bigint/
 .. _BN.js: https://github.com/indutny/bn.js/
 .. _BigNumber.js: https://github.com/MikeMcl/bignumber.js/
@@ -216,6 +224,10 @@ We may calculate the position ID for the position ``$:(A|B)`` via:
 The ID for ``$:(A|B)`` turns out to be ``0x6147e75d1048cea497aeee64d1a4777e286764ded497e545e88efc165c9fc4f0``.
 
 Similarly, the ID for ``$:(LO)`` can be found to be ``0xfdad82d898904026ae6c01a5800c0a8ee9ada7e7862f9bb6428b6f81e06f53bb``, and ``$:(A|B)&(LO)`` has an ID of ``0xcc77e750b61d29e158aa3193faa3673b2686ba9f6a16f51b5cdbea2a4f694be0``.
+
+A helper function for calculating positions also exists:
+
+.. autosolfunction:: ConditionalTokens.getPositionID
 
 .. _ERC20: https://theethereum.wiki/w/index.php/ERC20_Token_Standard
 


### PR DESCRIPTION
@xavierlepretre

So it looks like deduplicating the IDs and exposing them as part of the public interface would indeed decrease code size, but it would also increase the cost per transaction for everything (as there would be a JMP to and from the deduplicated code section instead of having the logic being "inlined").

Also, since these calls are public, there would be additional ABI parsing logic prepended to those code sections and JMPDESTS for their corresponding function selectors, so I was curious if that overhead would cancel the deduplication size, but as you can see, deployment costs were reduced, so it looks like overall, the deduplication had the intended effect on code size.

Closes #31 